### PR TITLE
Use Typheous as the HTTP client

### DIFF
--- a/algoliasearch.gemspec
+++ b/algoliasearch.gemspec
@@ -63,17 +63,17 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency     'httpclient', '~> 2.8', '>= 2.8.3'
+      s.add_runtime_dependency     'typhoeus',   '~> 1.3', '>= 1.3.1'
       s.add_runtime_dependency     'json',       '>= 1.5.1'
       s.add_development_dependency 'travis',     '~> 0'
       s.add_development_dependency 'rake',       '~> 0'
       s.add_development_dependency 'rdoc',       '~> 0'
     else
-      s.add_dependency             'httpclient', '~> 2.8', '>= 2.8.3'
+      s.add_dependency             'typhoeus',   '~> 1.3', '>= 1.3.1'
       s.add_dependency             'json',       '>= 1.5.1'
     end
   else
-    s.add_dependency               'httpclient', '~> 2.8', '>= 2.8.3'
+    s.add_dependency               'typhoeus',   '~> 1.3', '>= 1.3.1'
     s.add_dependency               'json',       '>= 1.5.1'
   end
 end

--- a/lib/algolia/analytics.rb
+++ b/lib/algolia/analytics.rb
@@ -47,7 +47,7 @@ module Algolia
     private
 
     def perform_request(method, url, params = {}, data = {})
-      http = HTTPClient.new
+      http = Typhoeus
 
       url = API_URL + url
 
@@ -56,18 +56,18 @@ module Algolia
 
       response = case method
                  when :GET
-                   http.get(url, { :header => @headers })
+                   http.get(url, { :headers => @headers })
                  when :POST
-                   http.post(url, { :body => data, :header => @headers })
+                   http.post(url, { :body => data, :headers => @headers })
                  when :DELETE
-                   http.delete(url, { :header => @headers })
+                   http.delete(url, { :headers => @headers })
                  end
 
       if response.code / 100 != 2
-        raise AlgoliaProtocolError.new(response.code, "Cannot #{method} to #{url}: #{response.content}")
+        raise AlgoliaProtocolError.new(response.code, "Cannot #{method} to #{url}: #{response.body}")
       end
 
-      JSON.parse(response.content)
+      JSON.parse(response.body)
     end
 
   end

--- a/lib/algoliasearch.rb
+++ b/lib/algoliasearch.rb
@@ -5,14 +5,7 @@
 ## Thanks to Sylvain Utard for the initial version of the library
 ## ----------------------------------------------------------------------
 require 'json'
-if !defined?(RUBY_ENGINE) && defined?(RUBY_VERSION) && RUBY_VERSION == '1.8.7'
-  # work-around a limitation from nahi/httpclient, using the undefined RUBY_ENGINE constant
-  RUBY_ENGINE = 'ruby1.8'
-  require 'httpclient'
-  Object.send(:remove_const, :RUBY_ENGINE)
-else
-  require 'httpclient'
-end
+require 'typhoeus'
 require 'date'
 require 'cgi'
 require 'pathname'


### PR DESCRIPTION
This is an example of replacing the `HTTPClient` gem with `Typheous` for all http and https calls in the gem.

Test not run on CI are Multi cluster and AB testing as these are premium features I haven't enabled on my trial account.

